### PR TITLE
We should specify our fork in the version

### DIFF
--- a/pyrise/__init__.py
+++ b/pyrise/__init__.py
@@ -5,7 +5,7 @@ import sys
 from datetime import datetime, timedelta
 from xml.etree import ElementTree
 
-__version__ = '0.4.4'
+__version__ = '0.4.4.zapier'
 
 
 class _Request(object):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name="pyrise",
-      version='0.4.4',
+      version='0.4.4.zapier',
       description="Python wrapper for 37Signals Highrise",
       long_description="A work in progress, but one that will be awesome when finished. Pyrise gives you class objects that work a lot like Django models, making the whole experience of integrating with Highrise just a little more awesome and Pythonic.",
       license="MIT License",


### PR DESCRIPTION
There's an issue on our workers now where some boxes are running our version of 0.4.4 and others are running the legitimate 0.4.4 from pypi. This locks our fork to a very specific version that indicates we are the owners and should alleviate accidentally running the wrong version.
