### PR TITLE
Bring back the removed hooks support and use six for Python 2/3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name="pyrise",
       author_email="jason@feedmagnet.com",
       url="http://github.com/feedmagnet/pyrise",
       py_modules=['pyrise'],
-      install_requires = ['httplib2', 'requests'],
+      install_requires = ['httplib2', 'requests', 'six'],
       keywords= "python 37signals highrise api wrapper feedmagnet",
       classifiers=[
          "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I tried to canary this but when it failed, I noticed that the hooks support was removed in https://github.com/zapier/pyrise/pull/4.
